### PR TITLE
Update Build & Deploy workflow to 0.11.1

### DIFF
--- a/.github/workflows/moonscript_release.yml
+++ b/.github/workflows/moonscript_release.yml
@@ -1,0 +1,82 @@
+name: Create Moonscript Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: CD
+        run: cd $GITHUB_WORKSPACE
+
+      - name: Update apt
+        run: sudo apt-get update -y
+
+      - name: Install LuaRocks
+        run: sudo apt-get install -y luarocks
+
+      - name: Install Moonscript
+        run: sudo luarocks install moonscript
+
+      - name: Build Lua
+        run: moonc -t lua moon/*
+
+      - name: Remove moon
+        run: rm -rf moon
+
+      - name: Remove github dir
+        run: rm -rf .github
+
+      - name: Create VERSION file
+        run: versionStr=${{ github.ref }};echo -e v${versionStr#*v} > VERSION
+
+      - name: Push to lua branch
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "Release build: $(cat VERSION)"
+          git push -f origin HEAD:lua
+
+      - name: Remove .git dir
+        run: rm -rf .git
+
+      - name: Create subdirectory
+        run: mkdir ${{ github.event.repository.name }}
+
+      - name: Move files into sub directory
+        run: ls | grep -v ${{ github.event.repository.name }} | xargs mv -t ${{ github.event.repository.name }}
+
+      - name: Create Release Asset
+        run: zip -r9 ${{ github.event.repository.name }}.zip .
+
+      - name: Publish Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: Latest Release with pre-compiled Lua (Ready to put in your addons directory)
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ github.event.repository.name }}.zip
+          asset_name: ${{ github.event.repository.name }}.zip
+          asset_content_type: application/zip
+
+# forced_update_count: 2


### PR DESCRIPTION
This PR was automatically triggered due to [a change in the base `moonscript_release` workflow](https://github.com/CFC-Servers/github_action_workflows/compare/0.11..0.11.1)