### PR TITLE
Add scopes, callback inheritance, change forced file to convar

### DIFF
--- a/moon/includes/modules/cfclogger.moon
+++ b/moon/includes/modules/cfclogger.moon
@@ -1,32 +1,33 @@
-import Read from file
-import gsub from string
 import insert, concat, ToString from table
+import istable, pairs, print, tostring from _G
 
-LOG_LEVEL_OVERRIDE = (
-    ->
-        contents = Read "cfc/logger/forced_log_level.txt", "DATA"
-        contents and gsub(contents, "%s", "") or nil
-)!
+LOG_LEVEL_OVERRIDE = CreateConVar "cfc_logger_forced_level", ""
+forcedLogLevel = ->
+    level = LOG_LEVEL_OVERRIDE\GetString!
+    level == "" and nil or level
 
-export CFCLogger
-class CFCLogger
-    @@severities = {
-        "trace": 0,
-        "debug": 1,
-        "info": 2,
-        "warn": 3,
-        "error": 4,
-        "fatal": 5
-    }
+export class CFCLogger
+    @@severities =
+        trace: 0
+        debug: 1
+        info: 2
+        warn: 3
+        error: 4
+        fatal: 5
 
-    new: (projectName, logLevel) =>
-        @projectName = projectName
-        @logLevel = LOG_LEVEL_OVERRIDE or logLevel or "info"
+    new: (@name, logLevel, @parent) =>
+        @prefix = @parent and @parent.prefix or ""
+        @prefix ..= "[#{@name}] "
+
+        @logLevel = forcedLogLevel! or logLevel or "info"
         @callbacks = { severity,{} for severity in pairs @@severities }
 
         for severity in pairs @@severities
             @[severity] = (...) =>
                 @_log(severity, ...)
+
+    scope: (scope, logLevel=@logLevel) =>
+        CFCLogger scope, logLevel, self
 
     addCallbackFor: (severity, callback) =>
         insert @callbacks[severity], callback
@@ -34,14 +35,17 @@ class CFCLogger
     runCallbacksFor: (severity, message) =>
         callback message for callback in *@callbacks[severity]
 
-    on: (severity) =>
-        scope = self
+        return unless @parent
+        return unless @runParentCallbacks
 
-        addCallback = (callback) => scope.addCallbackFor(scope, severity, callback)
+        @parent\runCallbacksFor severity, message
+
+    on: (severity) =>
+        addCallback = (callback) -> @addCallbackFor(scope, severity, callback)
 
         { call: addCallback }
 
-    formatParams: (...) =>
+    _formatParams: (...) =>
         values = {...}
 
         -- Ensure all values are strings
@@ -52,10 +56,11 @@ class CFCLogger
     _log: (severity, ...) =>
         return if @@severities[severity] < @@severities[@logLevel]
 
-        message = @formatParams ...
-        print "[#{@projectName}] [#{severity}] #{message}"
+        messageParams = @_formatParams ...
+        message = "#{@prefix}[#{severity}] #{messageParams}"
 
-        @runCallbacksFor(severity, message)
+        print message
 
-cfcLogger = CFCLogger "CFC Logger"
-cfcLogger\info "Loaded!"
+        @runCallbacksFor severity, message
+
+CFCLogger("CFC Logger")\info "Loaded!"


### PR DESCRIPTION
This lets people make scopes on an existing logger, i.e.

```lua
local MyProject = {}
MyProject.Logger = CFCLogger( "MyProject" )

MyProject.Storage = {}
MyProject.Storage.Logger = MyProject.Logger:scope( "Storage" )

MyProject.Logger:info( "Info from MyProject!" )
MyProject.Storage.Logger:info( "Info from Storage!" )
```

would print:

```
[MyProject] [info] Info from MyProject!
[MyProject] [Storage] [info] Info from Storage!
```

This also lets you inherit callbacks from a scoped logger's parent:
```lua
MyProject.Storage.Logger.runParentCallbacks = true
```
Will then inherit all callbacks set on `MyProject.Logger`


Finally, I also got rid of the `forced_log_level.txt` file and changed it to a convar instead. Just seems reasonable.
This also lets you change the forced log level while the game is running, which is pretty rad.